### PR TITLE
Improve README readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,28 +5,32 @@
 [![Coverage Status](https://coveralls.io/repos/github/raeperd/stepdown/badge.svg?branch=main)](https://coveralls.io/github/raeperd/stepdown?branch=main)
 [![Go Reference](https://pkg.go.dev/badge/github.com/raeperd/stepdown.svg)](https://pkg.go.dev/github.com/raeperd/stepdown)
 
-Go linter that checks callers are declared before callees — the **Stepdown Rule** from Clean Code.
+Go linter that keeps your code reading top-to-bottom like a newsletter.
 
-## Why
+```
+main.go:20:1: function "bar" is called by "foo" but declared before it (stepdown rule)
+```
 
-Robert C. Martin's *Clean Code* introduces the **Stepdown Rule**: functions should be ordered so that callers appear before callees, and code reads top-to-bottom like a narrative. Kent Beck echoes this as **Reading Order** in *Tidy First?*.
+## What is the Stepdown Rule?
 
-No Go linter currently enforces this. `stepdown` fills that gap.
+Robert C. Martin's *Clean Code* calls it the **Stepdown Rule**. Kent Beck calls it **Reading Order** in *Tidy First?*. Same idea — functions should be ordered so that each function appears above the functions it calls.
 
-## Installation
+## Install
 
 ```bash
-# Standalone
 go install github.com/raeperd/stepdown/cmd/stepdown@latest
+```
 
-# With golangci-lint (recommended)
-# Add to .golangci.yml:
+Or with golangci-lint:
+
+```yaml
+# .golangci.yml
 linters:
   enable:
     - stepdown
 ```
 
-## Usage
+## Run
 
 ```bash
 stepdown ./...
@@ -36,12 +40,7 @@ go vet -vettool=$(which stepdown) ./...
 golangci-lint run
 ```
 
-Output:
-```
-main.go:20:1: function "bar" is called by "foo" but declared before it (stepdown rule)
-```
-
-## Configuration
+## Configure
 
 ```yaml
 # .golangci.yml
@@ -55,9 +54,9 @@ linters-settings:
 ## Contributing
 
 ```bash
-make build # Build binary
-make test  # Run tests
-make lint  # Run linter
+make build  # Build binary
+make test   # Run tests
+make lint   # Run linter
 ```
 
 ## License


### PR DESCRIPTION
## Summary
- Rewrite tagline: "Go linter that keeps your code reading top-to-bottom like a newsletter"
- Show example output right after tagline
- Move "What is the Stepdown Rule?" before install instructions
- Shorten section names (Install, Run, Configure)
- Fix confusing "callers before callees" phrasing

## Test plan
- [x] Verify README renders correctly on GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced the "Stepdown Rule" explanation with an improved introduction and repositioned example block at the top for better clarity and understanding
  * Reorganized major document sections with clearer, more intuitive heading names to improve overall structure, navigation, and general user experience
  * Refined installation, configuration, and development tooling guidance with cleaner formatting, simplified explanations, and more streamlined command documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->