### PR TITLE
chore: update GitHub Actions to latest versions and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,8 +12,8 @@ jobs:
         go-version: [ oldstable, stable ]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
       - name: Check and get dependencies
@@ -32,12 +32,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: golangci/golangci-lint-action@v8
+      - uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.4
+          version: v2.11
       - run: make build
       - run: go vet -vettool=./stepdown ./...


### PR DESCRIPTION
## Summary
- Update `actions/checkout` v4 → v6
- Update `actions/setup-go` v5 → v6
- Update `golangci/golangci-lint-action` v8 → v9 (golangci-lint v2.4 → v2.11)
- Add Dependabot config for automatic `github-actions` and `gomod` updates

## Test plan
- [ ] CI build passes on all OS/Go version matrix
- [ ] Lint job passes with new golangci-lint version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow to use newer versions of core actions and linting tools.
  * Configured automated dependency update checks for GitHub Actions and Go modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->