### PR TITLE
Use qualified method names in diagnostics

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -102,8 +102,7 @@ func (a *analyzer) checkFile(pass *analysis.Pass, file *ast.File) {
 			continue
 		}
 		callerKey := funcKey(funcDecl)
-		callerName := shortName(callerKey)
-		if _, ok := a.exclusions[callerName]; ok {
+		if a.isExcluded(callerKey) {
 			continue
 		}
 		callerLine := pass.Fset.Position(funcDecl.Pos()).Line
@@ -117,8 +116,7 @@ func (a *analyzer) checkFile(pass *analysis.Pass, file *ast.File) {
 			if inCycle(calls, calleeKey, callerKey) {
 				continue
 			}
-			calleeName := shortName(calleeKey)
-			if _, ok := a.exclusions[calleeName]; ok {
+			if a.isExcluded(calleeKey) {
 				continue
 			}
 
@@ -129,7 +127,7 @@ func (a *analyzer) checkFile(pass *analysis.Pass, file *ast.File) {
 			if calleeLine < callerLine {
 				pass.Reportf(calleePos,
 					"function %q is called by %q but declared before it (stepdown rule)",
-					calleeName, callerName,
+					calleeKey, callerKey,
 				)
 			}
 
@@ -137,7 +135,7 @@ func (a *analyzer) checkFile(pass *analysis.Pass, file *ast.File) {
 			if calleeLine < maxLine {
 				pass.Reportf(calleePos,
 					"function %q is called by %q before %q but declared after it (stepdown rule)",
-					calleeName, callerName, shortName(maxKey),
+					calleeKey, callerKey, maxKey,
 				)
 			}
 			if calleeLine > maxLine {
@@ -174,6 +172,14 @@ func funcKey(funcDecl *ast.FuncDecl) string {
 		}
 	}
 	return funcDecl.Name.Name
+}
+
+func (a *analyzer) isExcluded(key string) bool {
+	if _, ok := a.exclusions[key]; ok {
+		return true
+	}
+	_, ok := a.exclusions[shortName(key)]
+	return ok
 }
 
 func shortName(key string) string {

--- a/analyzer.go
+++ b/analyzer.go
@@ -27,7 +27,11 @@ func NewAnalyzer(s Settings) *analysis.Analyzer {
 
 // Settings is the configuration for the analyzer.
 type Settings struct {
-	// Exclusions is a list of function names to exclude from checks (e.g. "init", "main").
+	// Exclusions is a list of names to exclude from checks.
+	// Supported forms:
+	//   - plain function names (e.g. "init", "main")
+	//   - exact qualified method names (e.g. "Server.handle")
+	//   - short method names that match across receiver types (e.g. "handle")
 	Exclusions []string
 }
 

--- a/analyzer.go
+++ b/analyzer.go
@@ -27,11 +27,10 @@ func NewAnalyzer(s Settings) *analysis.Analyzer {
 
 // Settings is the configuration for the analyzer.
 type Settings struct {
-	// Exclusions is a list of names to exclude from checks.
-	// Supported forms:
-	//   - plain function names (e.g. "init", "main")
-	//   - exact qualified method names (e.g. "Server.handle")
-	//   - short method names that match across receiver types (e.g. "handle")
+	// Exclusions is a list of function or method names to exclude from checks.
+	// Use plain names for functions, e.g. "init" or "main".
+	// Use receiver-qualified names for one method, e.g. "Server.handle".
+	// Use short method names to match across receiver types, e.g. "handle".
 	Exclusions []string
 }
 

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -26,3 +26,13 @@ func TestAnalyzerCalleeExclusion(t *testing.T) {
 	a := stepdown.NewAnalyzer(stepdown.Settings{Exclusions: []string{"excluded"}})
 	analysistest.Run(t, analysistest.TestData(), a, "callee_exclusion")
 }
+
+func TestAnalyzerQualifiedExclusion(t *testing.T) {
+	a := stepdown.NewAnalyzer(stepdown.Settings{Exclusions: []string{"Server.handle"}})
+	analysistest.Run(t, analysistest.TestData(), a, "qualified_exclusion")
+}
+
+func TestAnalyzerShortMethodExclusion(t *testing.T) {
+	a := stepdown.NewAnalyzer(stepdown.Settings{Exclusions: []string{"handle"}})
+	analysistest.Run(t, analysistest.TestData(), a, "short_method_exclusion")
+}

--- a/testdata/src/crossstruct/crossstruct.go
+++ b/testdata/src/crossstruct/crossstruct.go
@@ -2,7 +2,7 @@ package crossstruct
 
 type DB struct{}
 
-func (d *DB) query() {} // want `function "query" is called by "handle" but declared before it \(stepdown rule\)`
+func (d *DB) query() {} // want `function "DB.query" is called by "Handler.handle" but declared before it \(stepdown rule\)`
 
 type Handler struct {
 	db *DB

--- a/testdata/src/crossstruct/func_to_method.go
+++ b/testdata/src/crossstruct/func_to_method.go
@@ -2,7 +2,7 @@ package crossstruct
 
 type Logger struct{}
 
-func (l *Logger) log() {} // want `function "log" is called by "process" but declared before it \(stepdown rule\)`
+func (l *Logger) log() {} // want `function "Logger.log" is called by "process" but declared before it \(stepdown rule\)`
 
 func process(l *Logger) {
 	l.log()

--- a/testdata/src/methods/methods.go
+++ b/testdata/src/methods/methods.go
@@ -2,7 +2,7 @@ package methods
 
 type Server struct{}
 
-func (s *Server) handle() {} // want `function "handle" is called by "run" but declared before it \(stepdown rule\)`
+func (s *Server) handle() {} // want `function "Server.handle" is called by "Server.run" but declared before it \(stepdown rule\)`
 
 func (s *Server) run() {
 	s.handle()

--- a/testdata/src/methods/value_receiver.go
+++ b/testdata/src/methods/value_receiver.go
@@ -2,7 +2,7 @@ package methods
 
 type Config struct{}
 
-func (c Config) validate() {} // want `function "validate" is called by "load" but declared before it \(stepdown rule\)`
+func (c Config) validate() {} // want `function "Config.validate" is called by "Config.load" but declared before it \(stepdown rule\)`
 
 func (c Config) load() {
 	c.validate()

--- a/testdata/src/qualified_exclusion/qualified_exclusion.go
+++ b/testdata/src/qualified_exclusion/qualified_exclusion.go
@@ -1,0 +1,18 @@
+package qualified_exclusion
+
+type Server struct{}
+
+// No violation — Server.handle is excluded exactly.
+func (s *Server) handle() {}
+
+func (s *Server) run() {
+	s.handle()
+}
+
+type Client struct{}
+
+func (c *Client) handle() {} // want `function "Client.handle" is called by "Client.run" but declared before it \(stepdown rule\)`
+
+func (c *Client) run() {
+	c.handle()
+}

--- a/testdata/src/short_method_exclusion/short_method_exclusion.go
+++ b/testdata/src/short_method_exclusion/short_method_exclusion.go
@@ -1,0 +1,17 @@
+package short_method_exclusion
+
+type Server struct{}
+
+func (s *Server) handle() {}
+
+func (s *Server) run() {
+	s.handle()
+}
+
+type Client struct{}
+
+func (c *Client) handle() {}
+
+func (c *Client) run() {
+	c.handle()
+}


### PR DESCRIPTION
## Summary
- show qualified method names in diagnostics, e.g. `Server.handle`
- support exact qualified exclusions while keeping short-name wildcard exclusions
- add tests for qualified diagnostics and exclusion behavior

Fixes #26

## Test
- `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Exclusion rules now correctly match both fully-qualified method names (e.g., "Server.handle") and short method names (e.g., "handle").

* **Improvements**
  * Violation messages now display fully-qualified method and function names for improved clarity and context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->