### PR TITLE
Polish analyzer behavior before v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,35 +21,27 @@ Robert C. Martin's *Clean Code* calls it the **Stepdown Rule**. Kent Beck calls 
 go install github.com/raeperd/stepdown/cmd/stepdown@latest
 ```
 
-Or with golangci-lint:
-
-```yaml
-# .golangci.yml
-linters:
-  enable:
-    - stepdown
-```
-
 ## Run
 
 ```bash
 stepdown ./...
 # or
 go vet -vettool=$(which stepdown) ./...
-# or
-golangci-lint run
 ```
 
 ## Configure
 
-```yaml
-# .golangci.yml
-linters-settings:
-  stepdown:
-    exclusions:
-      - "init"
-      - "main"
+Programmatic integrations can pass exclusions through `Settings`:
+
+```go
+stepdown.NewAnalyzer(stepdown.Settings{
+	Exclusions: []string{"init", "main", "Server.handle", "handle"},
+})
 ```
+
+Exclusions support plain function names, receiver-qualified method names, and short method names that match across receiver types.
+
+Native golangci-lint support is planned in [#8](https://github.com/raeperd/stepdown/issues/8).
 
 ## Contributing
 

--- a/analyzer.go
+++ b/analyzer.go
@@ -176,15 +176,27 @@ func funcName(fn *types.Func) string {
 
 func funcKey(funcDecl *ast.FuncDecl) string {
 	if funcDecl.Recv != nil && len(funcDecl.Recv.List) > 0 {
-		t := funcDecl.Recv.List[0].Type
-		if star, ok := t.(*ast.StarExpr); ok {
-			t = star.X
-		}
-		if ident, ok := t.(*ast.Ident); ok {
-			return ident.Name + "." + funcDecl.Name.Name
+		if name := receiverName(funcDecl.Recv.List[0].Type); name != "" {
+			return name + "." + funcDecl.Name.Name
 		}
 	}
 	return funcDecl.Name.Name
+}
+
+func receiverName(expr ast.Expr) string {
+	switch expr := expr.(type) {
+	case *ast.Ident:
+		return expr.Name
+	case *ast.StarExpr:
+		return receiverName(expr.X)
+	case *ast.IndexExpr:
+		return receiverName(expr.X)
+	case *ast.IndexListExpr:
+		return receiverName(expr.X)
+	case *ast.ParenExpr:
+		return receiverName(expr.X)
+	}
+	return ""
 }
 
 func (a *analyzer) isExcluded(key string) bool {

--- a/analyzer.go
+++ b/analyzer.go
@@ -142,6 +142,7 @@ func (a *analyzer) checkFile(pass *analysis.Pass, file *ast.File) {
 					"function %q is called by %q but declared before it (stepdown rule)",
 					calleeKey, callerKey,
 				)
+				continue
 			}
 
 			// Violation: callees declared in different order than invoked

--- a/analyzer.go
+++ b/analyzer.go
@@ -98,6 +98,16 @@ func (a *analyzer) checkFile(pass *analysis.Pass, file *ast.File) {
 		}
 	}
 
+	for caller, callees := range calls {
+		declaredCallees := callees[:0]
+		for _, calleeKey := range callees {
+			if _, ok := funcs[calleeKey]; ok {
+				declaredCallees = append(declaredCallees, calleeKey)
+			}
+		}
+		calls[caller] = declaredCallees
+	}
+
 	// Report caller-before-callee violations and callee invocation order violations
 	for _, decl := range file.Decls {
 		funcDecl, ok := decl.(*ast.FuncDecl)

--- a/analyzer.go
+++ b/analyzer.go
@@ -147,7 +147,7 @@ func (a *analyzer) checkFile(pass *analysis.Pass, file *ast.File) {
 			// Violation: callees declared in different order than invoked
 			if calleeLine < maxLine {
 				pass.Reportf(calleePos,
-					"function %q is called by %q before %q but declared after it (stepdown rule)",
+					"function %q is called by %q after %q but declared before it (stepdown rule)",
 					calleeKey, callerKey, maxKey,
 				)
 			}

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -16,6 +16,7 @@ func TestAnalyzer(t *testing.T) {
 	analysistest.Run(t, analysistest.TestData(), a, "calleeorder")
 	analysistest.Run(t, analysistest.TestData(), a, "crossstruct")
 	analysistest.Run(t, analysistest.TestData(), a, "interfacecall")
+	analysistest.Run(t, analysistest.TestData(), a, "genericmethods")
 }
 
 func TestAnalyzerExclusions(t *testing.T) {

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -17,6 +17,7 @@ func TestAnalyzer(t *testing.T) {
 	analysistest.Run(t, analysistest.TestData(), a, "crossstruct")
 	analysistest.Run(t, analysistest.TestData(), a, "interfacecall")
 	analysistest.Run(t, analysistest.TestData(), a, "genericmethods")
+	analysistest.Run(t, analysistest.TestData(), a, "duplicatereports")
 }
 
 func TestAnalyzerExclusions(t *testing.T) {

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -15,6 +15,7 @@ func TestAnalyzer(t *testing.T) {
 	analysistest.Run(t, analysistest.TestData(), a, "circular")
 	analysistest.Run(t, analysistest.TestData(), a, "calleeorder")
 	analysistest.Run(t, analysistest.TestData(), a, "crossstruct")
+	analysistest.Run(t, analysistest.TestData(), a, "interfacecall")
 }
 
 func TestAnalyzerExclusions(t *testing.T) {

--- a/testdata/src/calleeorder/calleeorder.go
+++ b/testdata/src/calleeorder/calleeorder.go
@@ -5,6 +5,6 @@ func run() {
 	second()
 }
 
-func second() {} // want `function "second" is called by "run" before "first" but declared after it \(stepdown rule\)`
+func second() {} // want `function "second" is called by "run" after "first" but declared before it \(stepdown rule\)`
 
 func first() {}

--- a/testdata/src/duplicatereports/duplicatereports.go
+++ b/testdata/src/duplicatereports/duplicatereports.go
@@ -1,0 +1,10 @@
+package duplicatereports
+
+func a() {} // want `function "a" is called by "run" but declared before it \(stepdown rule\)`
+
+func run() {
+	b()
+	a()
+}
+
+func b() {}

--- a/testdata/src/genericmethods/genericmethods.go
+++ b/testdata/src/genericmethods/genericmethods.go
@@ -1,0 +1,9 @@
+package genericmethods
+
+type Box[T any] struct{}
+
+func (b Box[T]) handle() {} // want `function "Box.handle" is called by "Box.run" but declared before it \(stepdown rule\)`
+
+func (b Box[T]) run() {
+	b.handle()
+}

--- a/testdata/src/interfacecall/interfacecall.go
+++ b/testdata/src/interfacecall/interfacecall.go
@@ -1,0 +1,9 @@
+package interfacecall
+
+type Worker interface {
+	work()
+}
+
+func run(w Worker) {
+	w.work()
+}


### PR DESCRIPTION
## Summary
- ignore interface methods and other same-file callees without function declarations
- support generic receiver method keys such as `Box.handle`
- fix callee-order diagnostic wording
- suppress duplicate callee-order diagnostics when caller-before-callee already reports
- clarify README usage before native golangci-lint support lands

## Test
- `go test ./...`
- `make lint`